### PR TITLE
added google analytics functionality to monitor site traffic

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'X_________X', 'auto');
+ga('send', 'pageview');
+</script>
   <title>Ian Knox</title>
   <meta name="author" content="Ian Knox, LLC">
   <meta name="Keywords" content="Denver, Colorado, Ian, Knox, Rails, Ruby, Python, Django, CSS, HTML, Javascript, Angular, Galvanize, gSchool, developer, software, engineer, bikes, bike, bicycle, bicycles, music, electronic, edm">


### PR DESCRIPTION
Hey Ian, I wanted to put out some PRs to contribute to people's projects. Here is some simple code to enable Google analytics to see how much traffic your site is getting...

-Merge this code
-Visit - http://www.google.com/analytics/
-Sign in > Google Analytics > gmail creds login> create new account
- provide name, provide website url, and industry (for tracking purposes), then click get Tracking ID. 

The id will be provided and all you have to do is merge these changes but replace the X_______X area with the ID provided by Google Analytics. 

Enjoy!
